### PR TITLE
fix:table name may not be the same as in the database

### DIFF
--- a/internal/entimport/import.go
+++ b/internal/entimport/import.go
@@ -233,7 +233,7 @@ func isJoinTable(table *schema.Table) bool {
 }
 
 func typeName(tableName string) string {
-	return inflect.Camelize(inflect.Singularize(tableName))
+	return inflect.Camelize(tableName)
 }
 
 func tableName(typeName string) string {


### PR DESCRIPTION
When I use entimport to generate ent code, if the table name in the database ends with `s`, it will be trimmed. In order to make the generated code consistent with the database, it is recommended not to call this method.

for example, my table name is `profit_and_loss`, and the generated file name is `profit_and_los.go`

```go
// old version
func typeName(tableName string) string {
	return inflect.Camelize(inflect.Singularize(tableName))
}

// new version
func typeName(tableName string) string {
	return inflect.Camelize(tableName)
}
```